### PR TITLE
Add CSV log replay and model import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# Petri Nets Visualizer
 
+This project lets you design and simulate simple Petri nets directly in the browser.  
+
+## Features
+
+- Create places, transitions and arcs.
+- Export or import a model using JSON files.
+- Load an event log from a CSV file and replay it on the model.
+- Filter the log by `case_id` to replay either the whole log or a single trace.
+
+## Event log format
+
+CSV files must contain the following columns:
+
+```
+case_id,timestamp,activity
+```
+
+Each row represents an event. `activity` must match the key of a transition in the model.
+
+## Running
+
+Open `pnet.html` in a browser. Use the toolbar to build or load a model.  
+The **Load Log** button lets you choose a CSV log. After loading, select a `case_id` from the dropdown or keep `All` and press **Run** to replay the log on the Petri net.

--- a/js/logs.js
+++ b/js/logs.js
@@ -1,0 +1,128 @@
+var Logs = [];
+var LogsByCase = {};
+var LogQueue = [];
+var LogTimer = null;
+
+function load_log_file(file) {
+    ReadFromFile(file, function (event) {
+        parse_log_csv(event.target.result);
+    });
+}
+
+function parse_log_csv(text) {
+    Logs = [];
+    LogsByCase = {};
+    var lines = text.trim().split(/\r?\n/);
+    if (lines.length === 0) {
+        return;
+    }
+    // assume header case_id,timestamp,activity
+    lines.shift();
+    lines.forEach(function (line) {
+        if (!line.trim()) return;
+        var cols = line.split(",");
+        var item = {
+            case_id: cols[0].trim(),
+            timestamp: cols[1].trim(),
+            activity: cols[2].trim()
+        };
+        Logs.push(item);
+        if (!LogsByCase[item.case_id]) {
+            LogsByCase[item.case_id] = [];
+        }
+        LogsByCase[item.case_id].push(item);
+    });
+    update_case_filter();
+}
+
+function update_case_filter() {
+    var sel = document.getElementById("caseFilter");
+    if (!sel) return;
+    sel.innerHTML = "";
+    var optAll = document.createElement("option");
+    optAll.value = "*";
+    optAll.text = "All";
+    sel.appendChild(optAll);
+    Object.keys(LogsByCase).forEach(function (id) {
+        var opt = document.createElement("option");
+        opt.value = id;
+        opt.text = id;
+        sel.appendChild(opt);
+    });
+}
+
+function prepare_log_simulation() {
+    var sel = document.getElementById("caseFilter");
+    var selected = sel ? sel.value : "*";
+    var cases = selected === "*" ? Object.keys(LogsByCase) : [selected];
+    LogQueue = [];
+    cases.forEach(function (id) {
+        LogQueue = LogQueue.concat(LogsByCase[id]);
+    });
+    LogQueue.sort(function (a, b) {
+        return new Date(a.timestamp) - new Date(b.timestamp);
+    });
+    reset_log_tokens(cases.length);
+}
+
+function start_log_simulation() {
+    prepare_log_simulation();
+    if (LogTimer) {
+        clearInterval(LogTimer);
+    }
+    IsRunning = true;
+    LogTimer = setInterval(step_log_simulation, AnimateDelay);
+}
+
+function step_log_simulation() {
+    if (LogQueue.length === 0) {
+        stop_log_simulation();
+        return;
+    }
+    var ev = LogQueue.shift();
+    fire_transition_name(ev.activity);
+}
+
+function stop_log_simulation() {
+    if (LogTimer) {
+        clearInterval(LogTimer);
+        LogTimer = null;
+    }
+    IsRunning = false;
+}
+
+function reset_log_tokens(count) {
+    Object.keys(Places).forEach(function (k) {
+        remove_tokens(Places[k]);
+        Places[k].tokens = [];
+    });
+    var startPlaces = Object.keys(Places).filter(function (pKey) {
+        return !Arcs.some(function (a) { return a.to.key === pKey; });
+    });
+    if (startPlaces.length === 0) return;
+    var start = Places[startPlaces[0]];
+    for (var i = 0; i < count; i++) {
+        AddToken(start);
+    }
+}
+
+function fire_transition_name(name) {
+    var t = Trans[name];
+    if (!t) {
+        console.log("Transition " + name + " not found");
+        return;
+    }
+    var arcsIn = get_arcsIn(name);
+    for (var i = 0; i < arcsIn.length; i++) {
+        if (arcsIn[i].from.tokens.length === 0) {
+            return;
+        }
+    }
+    arcsIn.forEach(function (a) {
+        RemoveToken(a.from);
+    });
+    var arcsOut = get_arcsOut(name);
+    arcsOut.forEach(function (a) {
+        AddToken(a.to);
+    });
+}

--- a/pnet.html
+++ b/pnet.html
@@ -19,8 +19,9 @@
     <script src="js/pnet_run.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/ui.js"></script>
-	<style>
-	.fa-cog{font-size:36px;color:red;}
+    <script src="js/logs.js"></script>
+        <style>
+        .fa-cog{font-size:36px;color:red;}
         .cursor-hand {
             cursor: pointer;
         }
@@ -71,6 +72,14 @@
                     <button class="btn btn-danger btn-sm" id="btnStop">
                         <span class="glyphicon glyphicon-stop"></span> Stop
                     </button>
+                </div>
+                &nbsp;
+                <div class="btn-group">
+                    <button class="btn btn-warning btn-sm" id="btnLoadLog">
+                        <span class="glyphicon glyphicon-upload"></span> Load Log
+                    </button>
+                    <input id="logFileInput" type="file" style="display:none;" />
+                    <select id="caseFilter" class="btn btn-default btn-sm"><option value="*">All</option></select>
                 </div>
                 &nbsp;
                 <div class="btn-group">
@@ -169,6 +178,12 @@
         ini_button("btnClearPaper", function () { clear_paper(); }, "Clear canvas");
         ini_button("btnRun", function () { run_clicked(); }, "Run Petri Net graph");
         ini_button("btnStop", function () { stop_clicked(); }, "Stop running");
+        ini_button("btnLoadLog", function () { document.getElementById('logFileInput').click(); }, "Load log from CSV");
+        document.getElementById('logFileInput').addEventListener('change', function () {
+            if (this.files.length > 0) {
+                load_log_file(this.files[0]);
+            }
+        });
         ini_button("btnSaveLocal", function () { save_local(); }, "Save to local memory");
         ini_button("btnRestoreLocal", function () { restore_local(); }, "Restore from local memory");
         ini_button("btnFalseInput", function () { open_clicked(); }, "Open from file");
@@ -241,14 +256,17 @@
     }
     function run_clicked() {
         //console.log("graph_loaded=" + graph_loaded());
-        if (graph_loaded()) {
+        if (Logs.length > 0) {
+            set_run_icon();
+            set_status("Running log...");
+            lock_status();
+            start_log_simulation();
+        } else if (graph_loaded()) {
             set_run_icon();
             set_status("Running...");
             lock_status();
             StartRun();
-        }
-        else
-        {
+        } else {
             set_status("No valid graph loaded.");
         }
     }
@@ -264,7 +282,11 @@
             set_default_icon();
             unlock_status();
             set_status("Stopped.");
-            StopRun();
+            if (LogTimer) {
+                stop_log_simulation();
+            } else {
+                StopRun();
+            }
         }
         else {
             set_status("There is no running graph.");


### PR DESCRIPTION
## Summary
- document project usage and event log format
- load CSV event logs and filter by case_id before simulation
- integrate log replay into existing Run/Stop controls

## Testing
- `node -e "require('./js/logs.js'); console.log('parsed');"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e23c94b288325b192e379ec63db9c